### PR TITLE
Defend against crash when the view layout is requested before the stats are loaded

### DIFF
--- a/RadarSTATS/Presentation/Modules/Charts/UI Components/SummaryStackView.swift
+++ b/RadarSTATS/Presentation/Modules/Charts/UI Components/SummaryStackView.swift
@@ -43,10 +43,7 @@ final class SummaryStackView: UIStackView {
     }
 
     func layout(mode: SummaryMode) {
-        guard self.stats != nil else {
-            return
-        }
-        
+        guard self.stats != nil else { return }
         switch mode {
         case .today:
             updateTodayStats()

--- a/RadarSTATS/Presentation/Modules/Charts/UI Components/SummaryStackView.swift
+++ b/RadarSTATS/Presentation/Modules/Charts/UI Components/SummaryStackView.swift
@@ -43,6 +43,10 @@ final class SummaryStackView: UIStackView {
     }
 
     func layout(mode: SummaryMode) {
+        guard self.stats != nil else {
+            return
+        }
+        
         switch mode {
         case .today:
             updateTodayStats()


### PR DESCRIPTION
This affected the Mac Catalyst version in which a layout request occurred before the stats where loaded.